### PR TITLE
Mirror of aws aws-sdk-java-v2#1971

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-685db17.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-685db17.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Fixing race condition in EventStreamAsyncResponseTransformer.  Field eventsToDeliver is a LinkedList, i.e., not thread-safe.  Accesses to field eventsToDeliver are protected by synchronization on itself, but not in 1 location."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
@@ -394,7 +394,9 @@ public final class EventStreamAsyncResponseTransformer<ResponseT, EventT>
         @Override
         public void onComplete() {
             // Add the special on complete event to signal drainEvents to complete the subscriber
-            eventsToDeliver.add(ON_COMPLETE_EVENT);
+            synchronized (eventsToDeliver) {
+                eventsToDeliver.add(ON_COMPLETE_EVENT);
+            }
             drainEventsIfNotAlready();
             transformFuture.complete(null);
         }


### PR DESCRIPTION
Mirror of aws aws-sdk-java-v2#1971
I also reported this at:

https://github.com/aws/aws-sdk-java-v2/issues/1972

# Description

Field `eventsToDeliver` is a `LinkedList` ([line 128](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L128)), i.e., not thread-safe.

Accesses to `eventsToDeliver` are protected by synchronization on itself (`synchronized (eventsToDeliver)`), e.g., at lines: [373-376](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L373-L376), [424-426](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L424-L426), [493-494](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493-L494), [493-498](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493-L498), and [493-506](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493-L506).

Note that  [line 506](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L506) (a `remove()`) and  [line 374](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L374) (`decoder` calls `handleMessage()` as per `decoder`'s definition at [line 110](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L110), and  `handleMessage()` calls `add()` at [line 271](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L271)) modify the `eventsToDeliver` (and are protected by synchronization at [line 493](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493) and  [line 373](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L373) respectively).

However, [line 397](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L397) (an `add()`, i.e., modifies `eventsToDeliver`) is not protected.

I see  [line 397](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L397) adds a `ON_COMPLETE_EVENT`, which, when processed in the `eventsToDeliver`, will signal termination (in `isCompletedOrDeliverEvent()` at [line 494](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L494)).

However, I think the `add()` at [line 397](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L397) can occur in parallel with the  `remove()` at  [line 506](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L506).  This is because the `remove()` at  [line 506](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L506) occurs for other messages in the `eventsToDeliver` that were already enqueued before the `ON_COMPLETE_EVENT`.  

I.e., when `ON_COMPLETE_EVENT` is being added by [line 397](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L397) other messages may still be getting processed from the `eventsToDeliver` queue.

Note how `isCompletedOrDeliverEvent()`  is getting called (by itself, recursively) at [lines 505-509](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L505-L509) until `eventsToDeliver` becomes empty  ([line 498](https://github.com/aws/aws-sdk-java-v2/blob/master/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L498)) or `ON_COMPLETE_EVENT` is encountered ([line 494](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L494)).

Note also how the recursive calls at [lines 505-509](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L505-L509) are asynchronous (which is likely part of the reason for which we have the synchronization).

Even if somehow we know that there is a guarantee that all calls to  [line 506](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L506) were finished before  [line 397](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L397) is called (seems unlikely, with all those asynchronous calls above---also, if we could enforce such a guarantee, we may have better ways to communicate completion than to enqueue `ON_COMPLETE_EVENT` in the shared `eventsToDeliver` queue), it still seems like a fragile guarantee to make, because external callers may not be aware of it (e.g., it is not documented) or about other timing assumptions.

# This Fix Code


This fix is very simple: just surround the `add()` at  [line 397](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L397) with a  `synchronized (eventsToDeliver)`, just like the other lines discussed above ([373-376](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L373-L376), [424-426](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L424-L426), [493-494](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493-L494), [493-498](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493-L498), and [493-506](https://github.com/aws/aws-sdk-java-v2/blob/411f08706fc1fe3e8dafbedd87fd330099ab5449/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L493-L506)).


# Testing

`mvn clean install`


# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

# License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

